### PR TITLE
Load .env variables before connecting to database

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,3 @@
-import os
-import psycopg2
-
-from dotenv import load_dotenv
-
-#import the flask class from the Flask package
 from flask import Flask, render_template, request
 from connect_tcp import init_connection_pool
 from migrate import migrate_db

--- a/connect_tcp.py
+++ b/connect_tcp.py
@@ -3,6 +3,15 @@ import psycopg2
 from psycopg2 import pool
 from dotenv import load_dotenv
 
+# Load environment variables from a .env file if present. The database
+# connection parameters below are read at import time, so it's important that
+# they are populated before attempting to access them. Previously the values
+# were read from os.environ without first loading the .env file, which caused
+# KeyError exceptions when running the application locally without exporting
+# the variables. Calling ``load_dotenv`` ensures that the expected variables are
+# available.
+load_dotenv()
+
 host = os.environ["DATABASE_HOST"]
 dbname = os.environ["DATABASE_NAME"]
 user = os.environ["DATABASE_USER"]


### PR DESCRIPTION
## Summary
- load environment variables from .env before reading database configuration
- drop unused imports from app module

## Testing
- `python -m py_compile app.py connect_tcp.py migrate.py`


------
https://chatgpt.com/codex/tasks/task_e_68a259379a54832faafa735e070545c5